### PR TITLE
Remove "Lessons" header in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,9 +96,6 @@
 
 
     <div class="container-fluid">
-        <div class="row justify-content-center px-3">
-            <h1 class="text-center" style="font-family: 'Nunito', sans-serif;">Lessons</h1>
-        </div>
         <div class="row justify-content-evenly text-center px-3 mt-5">
             <div class="col-4 animate__animated animate__fadeInUpBig wow" data-wow-delay="0.1s">
                 <a href="realnum.html" class="lesson-link">


### PR DESCRIPTION
lesson header may not be needed for kids to understand the function of the buttons, and also cleans up the webpage.